### PR TITLE
IReactToEventSystem<> Unity IL2CPP

### DIFF
--- a/src/SystemsRx/Executor/Handlers/Conventional/ReactToEventSystemHandler.cs
+++ b/src/SystemsRx/Executor/Handlers/Conventional/ReactToEventSystemHandler.cs
@@ -23,7 +23,7 @@ namespace SystemsRx.Executor.Handlers.Conventional
         {
             EventSystem = eventSystem;
             _systemSubscriptions = new Dictionary<ISystem, IDisposable>();
-            _setupSystemGenericMethodInfo = typeof(ReactToEventSystemHandler).GetMethod(nameof(SetupSystemGeneric), BindingFlags.Instance | BindingFlags.NonPublic);
+            _setupSystemGenericMethodInfo = typeof(ReactToEventSystemHandler).GetMethod(nameof(SetupSystemGeneric), BindingFlags.Instance);
         }
 
         public bool CanHandleSystem(ISystem system)
@@ -48,7 +48,7 @@ namespace SystemsRx.Executor.Handlers.Conventional
             _systemSubscriptions.Add(system, new CompositeDisposable(disposables));
         }
 
-        private IDisposable SetupSystemGeneric<T>(IReactToEventSystem<T> system)
+        public IDisposable SetupSystemGeneric<T>(IReactToEventSystem<T> system)
         { return EventSystem.Receive<T>().Subscribe(system.Process); }
         
         public void DestroySystem(ISystem system)

--- a/src/SystemsRx/Executor/Handlers/Conventional/ReactToEventSystemHandler.cs
+++ b/src/SystemsRx/Executor/Handlers/Conventional/ReactToEventSystemHandler.cs
@@ -23,7 +23,7 @@ namespace SystemsRx.Executor.Handlers.Conventional
         {
             EventSystem = eventSystem;
             _systemSubscriptions = new Dictionary<ISystem, IDisposable>();
-            _setupSystemGenericMethodInfo = typeof(ReactToEventSystemHandler).GetMethod(nameof(SetupSystemGeneric), BindingFlags.Instance);
+            _setupSystemGenericMethodInfo = typeof(ReactToEventSystemHandler).GetMethod(nameof(SetupSystemGeneric));
         }
 
         public bool CanHandleSystem(ISystem system)


### PR DESCRIPTION
Make ReactToEventSystemHandler usable in Unity IL2CPP again.
By exposing the hidden generic method it becomes possible to use it somewhere in a unity project so IL2CPP will generate code for that generic usage.